### PR TITLE
Implement minimal people-agent chat demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # AgentsChat
+
+AgentsChat is a simple group chat system where human users can interact with each other and with pluggable agents. The project contains a FastAPI backend and a very small HTML/JS frontend. The backend keeps data in memory for simplicity.
+
+## Running the backend
+
+```bash
+pip install -r requirements.txt
+uvicorn backend.main:app --reload
+```
+
+The API listens on `http://localhost:8000` by default.
+
+## Frontend
+
+Open `frontend/index.html` in a browser. The page provides a minimal interface for login and chatting.
+
+This is only a demonstration implementation and does not persist data. The code is structured so that it can be extended with a proper database and richer frontend later.
+
+## Features
+- Multi-user login and registration
+- Admin endpoints for managing agents and users
+- Group chat where members and agents can post messages
+- Agents are triggered when mentioned with `@name`
+- Users can add friends and create or join multiple groups
+- Messages can contain text or uploaded audio files
+
+This repository is intentionally minimal. It provides a starting point for further development of a full people-and-agent group chat system.

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import hashlib
+import secrets
+from typing import Optional
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+
+from .models import User
+from .store import store
+
+
+security = HTTPBearer()
+
+
+def hash_password(password: str) -> str:
+    return hashlib.sha256(password.encode("utf-8")).hexdigest()
+
+
+def create_token(user_id: str) -> str:
+    token = secrets.token_hex(16)
+    store.tokens[token] = user_id
+    return token
+
+
+def get_current_user(creds: HTTPAuthorizationCredentials = Depends(security)) -> User:
+    token = creds.credentials
+    user_id = store.tokens.get(token)
+    if not user_id:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+    user = store.users.get(user_id)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid user")
+    return user

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import List
+from uuid import uuid4
+
+import requests
+from fastapi import Depends, FastAPI, File, Form, HTTPException, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+
+from . import auth
+from .models import Agent, Group, Message, User
+from .store import store
+
+app = FastAPI(title="AgentsChat")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+UPLOAD_DIR = os.path.join(os.path.dirname(__file__), "..", "uploads")
+os.makedirs(UPLOAD_DIR, exist_ok=True)
+
+
+@app.post("/register")
+def register(username: str = Form(...), password: str = Form(...)):
+    if any(u.username == username for u in store.users.values()):
+        raise HTTPException(status_code=400, detail="Username already exists")
+    user = User(id=str(uuid4()), username=username, password_hash=auth.hash_password(password))
+    store.add_user(user)
+    token = auth.create_token(user.id)
+    return {"token": token}
+
+
+@app.post("/login")
+def login(username: str = Form(...), password: str = Form(...)):
+    for user in store.users.values():
+        if user.username == username and user.password_hash == auth.hash_password(password):
+            token = auth.create_token(user.id)
+            return {"token": token}
+    raise HTTPException(status_code=400, detail="Invalid credentials")
+
+
+@app.get("/me")
+def me(user: User = Depends(auth.get_current_user)):
+    return user
+
+
+# User management (admin)
+@app.get("/users")
+def list_users(user: User = Depends(auth.get_current_user)):
+    if not user.is_admin:
+        raise HTTPException(status_code=403, detail="Admin only")
+    return list(store.users.values())
+
+
+@app.delete("/users/{user_id}")
+def delete_user(user_id: str, user: User = Depends(auth.get_current_user)):
+    if not user.is_admin:
+        raise HTTPException(status_code=403, detail="Admin only")
+    store.users.pop(user_id, None)
+    return {"status": "deleted"}
+
+
+# Agent management (admin)
+@app.post("/agents")
+def create_agent(name: str = Form(...), description: str = Form(""), api_url: str = Form(""), user: User = Depends(auth.get_current_user)):
+    if not user.is_admin:
+        raise HTTPException(status_code=403, detail="Admin only")
+    agent = Agent(id=str(uuid4()), name=name, description=description, api_url=api_url)
+    store.add_agent(agent)
+    return agent
+
+
+@app.get("/agents")
+def list_agents(user: User = Depends(auth.get_current_user)):
+    return list(store.agents.values())
+
+
+@app.delete("/agents/{agent_id}")
+def delete_agent(agent_id: str, user: User = Depends(auth.get_current_user)):
+    if not user.is_admin:
+        raise HTTPException(status_code=403, detail="Admin only")
+    store.agents.pop(agent_id, None)
+    return {"status": "deleted"}
+
+
+# Group management
+@app.post("/groups")
+def create_group(name: str = Form(...), user: User = Depends(auth.get_current_user)):
+    group = Group(id=str(uuid4()), name=name, owner_id=user.id, members={user.id})
+    store.add_group(group)
+    user.groups.add(group.id)
+    return group
+
+
+@app.post("/groups/{group_id}/join")
+def join_group(group_id: str, user: User = Depends(auth.get_current_user)):
+    group = store.groups.get(group_id)
+    if not group:
+        raise HTTPException(status_code=404, detail="Group not found")
+    group.members.add(user.id)
+    user.groups.add(group_id)
+    return {"status": "joined"}
+
+
+@app.get("/groups/{group_id}/messages")
+def get_messages(group_id: str, user: User = Depends(auth.get_current_user)):
+    group = store.groups.get(group_id)
+    if not group or user.id not in group.members:
+        raise HTTPException(status_code=403, detail="Not a member")
+    return [m for m in store.messages.values() if m.group_id == group_id]
+
+
+@app.post("/groups/{group_id}/messages")
+def post_message(
+    group_id: str,
+    content: str = Form(""),
+    file: UploadFile | None = File(None),
+    user: User = Depends(auth.get_current_user),
+):
+    group = store.groups.get(group_id)
+    if not group or user.id not in group.members:
+        raise HTTPException(status_code=403, detail="Not a member")
+    msg_type = "text"
+    audio_path = None
+    if file:
+        msg_type = "audio"
+        audio_path = os.path.join(UPLOAD_DIR, f"{uuid4()}_{file.filename}")
+        with open(audio_path, "wb") as f:
+            f.write(file.file.read())
+    message = Message(id=str(uuid4()), group_id=group_id, sender_id=user.id, content=content, timestamp=datetime.utcnow(), type=msg_type, audio_path=audio_path)
+    store.add_message(message)
+    # call agent if '@name' present
+    for agent_id in group.agents:
+        agent = store.agents[agent_id]
+        pattern = f"@{agent.name}"
+        if pattern in content:
+            try:
+                resp = requests.post(agent.api_url, json={"message": content})
+                if resp.ok:
+                    agent_reply = Message(
+                        id=str(uuid4()),
+                        group_id=group_id,
+                        sender_id=agent_id,
+                        content=resp.text,
+                        timestamp=datetime.utcnow(),
+                    )
+                    store.add_message(agent_reply)
+            except Exception:
+                pass
+    return message
+
+
+@app.post("/friends/{friend_id}")
+def add_friend(friend_id: str, user: User = Depends(auth.get_current_user)):
+    if friend_id not in store.users:
+        raise HTTPException(status_code=404, detail="Friend not found")
+    user.friends.add(friend_id)
+    return {"status": "added"}
+
+
+@app.get("/groups")
+def my_groups(user: User = Depends(auth.get_current_user)):
+    return [store.groups[g] for g in user.groups if g in store.groups]
+
+
+@app.post("/groups/{group_id}/agents/{agent_id}")
+def add_agent_to_group(group_id: str, agent_id: str, user: User = Depends(auth.get_current_user)):
+    group = store.groups.get(group_id)
+    if not group or group.owner_id != user.id:
+        raise HTTPException(status_code=403, detail="Only owner can add agents")
+    if agent_id not in store.agents:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    group.agents.add(agent_id)
+    return {"status": "added"}

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, List, Optional, Set
+from pydantic import BaseModel, Field
+
+
+class User(BaseModel):
+    id: str
+    username: str
+    password_hash: str
+    is_admin: bool = False
+    friends: Set[str] = Field(default_factory=set)
+    groups: Set[str] = Field(default_factory=set)
+    openai_key: Optional[str] = None
+
+
+class Agent(BaseModel):
+    id: str
+    name: str
+    description: str
+    api_url: str
+
+
+class Group(BaseModel):
+    id: str
+    name: str
+    owner_id: str
+    members: Set[str] = Field(default_factory=set)
+    agents: Set[str] = Field(default_factory=set)
+
+
+class Message(BaseModel):
+    id: str
+    group_id: str
+    sender_id: str
+    content: str
+    timestamp: datetime
+    type: str = "text"  # text or audio
+    audio_path: Optional[str] = None

--- a/backend/store.py
+++ b/backend/store.py
@@ -1,0 +1,31 @@
+"""In-memory data store."""
+from __future__ import annotations
+
+from typing import Dict
+from uuid import uuid4
+
+from .models import Agent, Group, Message, User
+
+
+class DataStore:
+    def __init__(self) -> None:
+        self.users: Dict[str, User] = {}
+        self.groups: Dict[str, Group] = {}
+        self.agents: Dict[str, Agent] = {}
+        self.messages: Dict[str, Message] = {}
+        self.tokens: Dict[str, str] = {}  # token -> user_id
+
+    def add_user(self, user: User) -> None:
+        self.users[user.id] = user
+
+    def add_agent(self, agent: Agent) -> None:
+        self.agents[agent.id] = agent
+
+    def add_group(self, group: Group) -> None:
+        self.groups[group.id] = group
+
+    def add_message(self, message: Message) -> None:
+        self.messages[message.id] = message
+
+
+store = DataStore()

--- a/frontend/chat.js
+++ b/frontend/chat.js
@@ -1,0 +1,65 @@
+let token = "";
+let currentGroup = "";
+const api = "http://localhost:8000";
+
+function login() {
+  const username = document.getElementById("username").value;
+  const password = document.getElementById("password").value;
+  const form = new FormData();
+  form.append("username", username);
+  form.append("password", password);
+  fetch(api + "/login", { method: "POST", body: form })
+    .then(r => r.json())
+    .then(data => {
+      token = data.token;
+      document.getElementById("login").style.display = "none";
+      document.getElementById("chat").style.display = "block";
+      loadGroups();
+    });
+}
+
+function authHeaders() {
+  return { Authorization: "Bearer " + token };
+}
+
+function loadGroups() {
+  fetch(api + "/groups", { headers: authHeaders() })
+    .then(r => r.json())
+    .then(gs => {
+      const list = document.getElementById("groups");
+      list.innerHTML = "";
+      gs.forEach(g => {
+        const li = document.createElement("li");
+        li.textContent = g.name;
+        li.onclick = () => { currentGroup = g.id; loadMessages(); };
+        list.appendChild(li);
+      });
+    });
+}
+
+function createGroup() {
+  const name = document.getElementById("groupName").value;
+  const form = new FormData();
+  form.append("name", name);
+  fetch(api + "/groups", { method: "POST", body: form, headers: authHeaders() })
+    .then(() => loadGroups());
+}
+
+function loadMessages() {
+  if (!currentGroup) return;
+  fetch(`${api}/groups/${currentGroup}/messages`, { headers: authHeaders() })
+    .then(r => r.json())
+    .then(msgs => {
+      const div = document.getElementById("messages");
+      div.innerHTML = msgs.map(m => `<p><b>${m.sender_id}</b>: ${m.content}</p>`).join("\n");
+    });
+}
+
+function sendMessage() {
+  if (!currentGroup) return;
+  const content = document.getElementById("message").value;
+  const form = new FormData();
+  form.append("content", content);
+  fetch(`${api}/groups/${currentGroup}/messages`, { method: "POST", body: form, headers: authHeaders() })
+    .then(() => { document.getElementById("message").value = ""; loadMessages(); });
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>AgentsChat</title>
+</head>
+<body>
+    <h1>AgentsChat Demo</h1>
+    <div id="login">
+        <h3>Login</h3>
+        <input id="username" placeholder="username">
+        <input id="password" type="password" placeholder="password">
+        <button onclick="login()">Login</button>
+    </div>
+    <div id="chat" style="display:none;">
+        <h3>Your groups</h3>
+        <ul id="groups"></ul>
+        <input id="groupName" placeholder="new group name">
+        <button onclick="createGroup()">Create Group</button>
+        <hr>
+        <div id="messages"></div>
+        <input id="message" placeholder="message">
+        <button onclick="sendMessage()">Send</button>
+    </div>
+    <script src="chat.js"></script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+python-multipart
+requests
+openai


### PR DESCRIPTION
## Summary
- add FastAPI backend with in-memory store for users, groups, messages and agents
- include auth helpers and simple CRUD routes
- create minimal HTML/JS frontend for chatting
- provide project requirements and README instructions

## Testing
- `pytest -q` *(fails: command not found)*